### PR TITLE
:memo: 为 firefox 系添加网页图标，同时修复 firefox addon 链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 目前插件已在 [Chrome Web Store](https://chromewebstore.google.com/detail/bhbpmpflnpnkjanfgbjjhldccbckjohb)
 、[Microsoft Edge 加载项](https://microsoftedge.microsoft.com/addons/detail/keikkgfgidagjlicckkangkfgnbdjdnh)
-和 [Firefox Browser Add-Ons](https://addons.mozilla.org/zh-CN/firefox/addon/%E6%9F%A0%E6%AA%AC%E8%B5%B7%E5%A7%8B%E9%A1%B5/)
+和 [Firefox Browser Add-Ons](https://addons.mozilla.org/zh-CN/firefox/addon/lemon-new-tab/)
 上架
 
 > 你也可以 Clone 下来手动 Build 一份来使用

--- a/entrypoints/newtab/index.html
+++ b/entrypoints/newtab/index.html
@@ -2,6 +2,7 @@
 <html style="color-scheme: light dark">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/x-icon" href="/icon.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Set include/exclude if the page should be removed from some builds -->
     <meta name="manifest.include" content="['chrome', 'firefox', 'edge']" />


### PR DESCRIPTION
firefox 系浏览器(firefox, zen)的插件网页不会沿用插件的图标，手动在 index.html 中添加了相关内容，不影响 chromium 系浏览器的显示。

*同时修复了一下 README 中的 firefox addon 链接*